### PR TITLE
feat: Add startup scripts and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Docling Document Processor WebUI
 
 ![image](https://github.com/user-attachments/assets/790d82a1-48bc-417b-9a23-2098d1454291)
@@ -21,14 +20,51 @@ An automated tool for converting documents (PDF, Word, Excel, etc.) to Markdown.
 
 ## 🚀 Quick Start
 
-### Install dependencies
+For a more automated setup, you can use the provided startup scripts. These scripts handle virtual environment creation, dependency installation, and application launch.
+
+### Automated Startup Scripts
+
+**For Linux/macOS users:**
+1.  Make the script executable (if you haven't already done so, or if you downloaded it):
+    ```bash
+    chmod +x start.sh
+    ```
+2.  Run the script:
+    ```bash
+    ./start.sh
+    ```
+
+**For Windows users:**
+1.  Simply run the script by double-clicking `start.bat` or typing the following in your command prompt:
+    ```bash
+    start.bat
+    ```
+
+These scripts will:
+*   Check for Python 3.
+*   Create a Python virtual environment named `venv` if it doesn't already exist.
+*   Activate the virtual environment.
+*   Install (or update) all necessary dependencies from `requirements.txt`.
+*   Launch the `Docling-webui.py` application.
+*   Attempt to open your default web browser to `http://localhost:7860`.
+
+**Note:** The application might sometimes start on a different port if 7860 is occupied. Please check the console output from the script for the exact URL (e.g., `http://localhost:XXXX`) and open it manually if the browser doesn't point to the correct address.
+
+### Manual Setup
+
+If you prefer to set up and run the application manually:
+
+#### Install dependencies
 ```bash
 pip install -r requirements.txt
 ```
-### Launch service
+*(Ensure you are in a Python 3 environment or virtual environment before running this.)*
+
+#### Launch service
 ```bash
 python Docling-webui.py
 ```
+
 ## 📂 Supported Formats
 Documents: `.pdf, .docx, .pptx, .xlsx`
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,13 +18,54 @@
 - 结果文件自动保存至`./documents`
 
 ## 🚀 快速开始
+
+为了更便捷地启动应用，您可以使用项目提供的启动脚本。这些脚本会自动处理虚拟环境创建、依赖安装以及启动应用等步骤。
+
+### 自动化启动脚本
+
+**对于 Linux/macOS 用户:**
+1.  首先，确保脚本有执行权限 (如果尚未设置或刚下载脚本):
+    ```bash
+    chmod +x start.sh
+    ```
+2.  然后运行脚本:
+    ```bash
+    ./start.sh
+    ```
+
+**对于 Windows 用户:**
+1.  直接双击 `start.bat` 文件，或者在命令提示符 (cmd) 中输入以下命令运行:
+    ```bash
+    start.bat
+    ```
+
+这些脚本将会：
+*   检查 Python 3 是否已安装。
+*   如果 `venv` 虚拟环境尚不存在，则创建它。
+*   激活 `venv` 虚拟环境。
+*   从 `requirements.txt` 文件中安装或更新所有必要的依赖库。
+*   启动 `Docling-webui.py` (英文版UI) 或 `Docling-webui-ZH.py` (中文版UI) 应用。**请注意：** 启动脚本会优先尝试启动 `Docling-webui.py`。如果需要启动中文版，请修改 `start.sh` 或 `start.bat` 中对应的 `python Docling-webui.py` 为 `python Docling-webui-ZH.py`。
+*   尝试在您的默认浏览器中打开 `http://localhost:7860`。
+
+**重要提示：** 如果 7860 端口已被占用，应用程序可能会在其他端口启动。请留意脚本运行后控制台的输出信息，以获取实际的访问 URL (例如 `http://localhost:XXXX`)。如果浏览器未能自动打开正确的地址，请手动复制该 URL 到浏览器中访问。
+
+### 手动设置
+
+如果您倾向于手动设置和运行应用程序：
+
+#### 安装依赖
 ```bash
-# 安装依赖
 pip install -r requirements.txt
 ```
-### 启动服务
+*(请确保在执行此命令前，您已处于 Python 3 环境或已激活相应的虚拟环境。)*
+
+#### 启动服务
 ```bash
+# 启动中文版界面
 python Docling-webui-ZH.py
+
+# 或者启动英文版界面
+# python Docling-webui.py
 ```
 ## 📂 支持格式
 文档：`.pdf, .docx, .pptx, .xlsx`

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,107 @@
+@echo off
+setlocal
+
+REM Check for Python 3
+python --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Error: Python is not installed or not found in PATH.
+    echo Please install Python 3 and ensure it's added to your PATH.
+    goto :error_exit
+)
+
+python --version 2>&1 | findstr /C:"Python 3" >nul
+if %errorlevel% neq 0 (
+    echo Error: Python 3 is required. The installed version is not Python 3.
+    echo Please install Python 3.
+    goto :error_exit
+)
+echo Python 3 found.
+
+REM Virtual Environment
+if not exist "venv" (
+    echo Creating Python 3 virtual environment 'venv'...
+    python -m venv venv
+    if %errorlevel% neq 0 (
+        echo Error: Failed to create virtual environment.
+        goto :error_exit
+    )
+    echo Virtual environment 'venv' created.
+) else (
+    echo Virtual environment 'venv' already exists.
+)
+
+REM Activate Virtual Environment
+echo Activating virtual environment...
+if not exist "venv\Scripts\activate.bat" (
+    echo Error: venv\Scripts\activate.bat not found. Cannot activate virtual environment.
+    goto :error_exit
+)
+call venv\Scripts\activate.bat
+if %errorlevel% neq 0 (
+    echo Error: Failed to activate virtual environment.
+    goto :error_exit
+)
+echo Virtual environment activated.
+
+REM Install Dependencies
+echo Installing dependencies from requirements.txt...
+if not exist "requirements.txt" (
+    echo Error: requirements.txt not found.
+    call :deactivate_and_exit
+)
+pip install -r requirements.txt
+if %errorlevel% neq 0 (
+    echo Error: Failed to install dependencies.
+    call :deactivate_and_exit
+)
+echo Dependencies installed successfully or were already up-to-date.
+
+REM Start Application
+echo Starting Docling-webui.py...
+REM The 'start' command launches the Python script in a new window, allowing the batch script to continue.
+start "Docling WebUI" python Docling-webui.py
+if %errorlevel% neq 0 (
+    echo Error: Failed to start Docling-webui.py.
+    call :deactivate_and_exit
+)
+echo Docling-webui.py is starting. Check its console output for the exact URL and port.
+
+REM Open Browser
+echo Waiting for the server to start...
+timeout /t 5 /nobreak >nul
+
+echo Attempting to open http://localhost:7860 in your browser.
+echo Please check the console output from Docling-webui.py for the actual address if it's different.
+start http://localhost:7860
+
+echo Script finished. The application should be running.
+goto :cleanup
+
+:deactivate_and_exit
+REM This label is for deactivating venv if it was activated, then exiting.
+echo Deactivating virtual environment due to an error...
+if defined VIRTUAL_ENV (
+    call venv\Scripts\deactivate.bat
+)
+goto :error_exit
+
+:error_exit
+echo Script terminated due to an error.
+call :cleanup_exit
+
+:cleanup
+REM Clean up and exit script
+if defined VIRTUAL_ENV (
+    REM Deactivate if the script is ending normally and venv is active
+    REM This might not be strictly necessary as the parent cmd prompt will not be affected by 'call activate'
+    REM but it's good practice for scripts that might be sourced or have other side effects.
+    REM However, for a simple launcher, it might be better to leave the venv active if the user ran the script directly in their cmd.
+    REM For now, we'll assume the primary purpose is launching the app, so we won't explicitly deactivate here on normal exit.
+    echo Virtual environment is still active in this window if you ran the script directly.
+)
+endlocal
+exit /b 0
+
+:cleanup_exit
+endlocal
+exit /b 1

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Check for Python 3
+if ! command -v python3 &> /dev/null
+then
+    echo "Error: Python 3 is not installed. Please install Python 3 and try again."
+    exit 1
+fi
+echo "Python 3 found."
+
+# Virtual Environment
+if [ ! -d "venv" ]; then
+    echo "Creating Python 3 virtual environment 'venv'..."
+    python3 -m venv venv
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to create virtual environment."
+        exit 1
+    fi
+    echo "Virtual environment 'venv' created."
+else
+    echo "Virtual environment 'venv' already exists."
+fi
+
+# Activate Virtual Environment
+echo "Activating virtual environment..."
+source venv/bin/activate
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to activate virtual environment."
+    exit 1
+fi
+echo "Virtual environment activated."
+
+# Install Dependencies
+echo "Installing dependencies from requirements.txt..."
+if [ ! -f "requirements.txt" ]; then
+    echo "Error: requirements.txt not found."
+    # Deactivate venv on error
+    deactivate
+    exit 1
+fi
+pip install -r requirements.txt
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to install dependencies."
+    # Deactivate venv on error
+    deactivate
+    exit 1
+fi
+echo "Dependencies installed successfully or were already up-to-date."
+
+# Start Application
+echo "Starting Docling-webui.py in the background..."
+python3 Docling-webui.py &
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to start Docling-webui.py."
+    # Deactivate venv on error
+    deactivate
+    exit 1
+fi
+echo "Docling-webui.py is starting. Check its console output for the exact URL and port."
+
+# Open Browser
+echo "Waiting for the server to start..."
+sleep 5 # Wait for 5 seconds
+
+# Attempt to open the browser
+echo "Attempting to open http://localhost:7860 in your browser."
+echo "Please check the console output from Docling-webui.py for the actual address if it's different."
+if command -v xdg-open &> /dev/null; then
+    xdg-open http://localhost:7860
+elif command -v open &> /dev/null; then
+    open http://localhost:7860
+else
+    echo "Could not find xdg-open or open. Please open http://localhost:7860 (or the address shown in the Docling-webui.py console) in your browser manually."
+fi
+
+echo "Script finished. The application should be running in the background."
+# Note: The virtual environment remains active in the current shell if this script is sourced.
+# If the script is run directly (./start.sh), the venv activation is local to the script.
+# For Docling-webui.py running in the background, it uses the activated venv.


### PR DESCRIPTION
Adds `start.sh` (for Linux/macOS) and `start.bat` (for Windows) to automate the setup and launch of the Docling WebUI.

These scripts will:
- Check for Python 3.
- Create a Python virtual environment (`venv`) if one doesn't exist.
- Activate the virtual environment.
- Install dependencies from `requirements.txt`.
- Launch the `Docling-webui.py` application.
- Attempt to open the default web browser to `http://localhost:7860`.

The `README.md` and `README_zh.md` files have been updated to include instructions for using these new scripts, alongside the existing manual setup instructions. You are advised that the application might start on a different port if 7860 is busy, and you should check the console output for the correct URL.